### PR TITLE
create-react-app now requires Node v8+

### DIFF
--- a/create-react-app/Dockerfile
+++ b/create-react-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7-alpine
+FROM node:8-alpine
 
 RUN npm install -g create-react-app
 


### PR DESCRIPTION
Running create-react-app now causes this error because the current container uses Node v7 and one of its dependencies now requires Node v8+.

```
error @svgr/webpack@2.4.1: The engine "node" is incompatible with this module. Expected version ">=8".
error Found incompatible module
```

This PR updates the Docker container to run with Node v8.